### PR TITLE
Automatic gh-pages deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build # The folder the action should deploy.

--- a/src/components/FormDiv.tsx
+++ b/src/components/FormDiv.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 /* eslint-disable no-case-declarations */
 /* eslint-disable react/react-in-jsx-scope */
 import { Box, Checkbox, FormControlLabel, FormGroup, Radio, RadioGroup, TextField } from '@mui/material'

--- a/src/pages/homepage.tsx
+++ b/src/pages/homepage.tsx
@@ -40,6 +40,7 @@ export default function HomePage () {
               <li>Imprimables</li>
               <li>Maintien des données après avoir sauvegardé via le stockage local</li>
               <li>Mode sombre / mode clair</li>
+              <li>Gestion de plusieurs rapports pour les responsables</li>
             </p>
             <div className="homepageButtons">
               <Tooltip title="Créer un rapport de stage Stagiaire" arrow>


### PR DESCRIPTION
Deploying to github pages when a push is made in the `main` branch using `GitHub Actions`. It builds, and deploy to the `gh-pages` branch.
Also added `multi reports for responsibles` in the features on homepage.
Fixed a warning caused by eslint. 

Close #12 